### PR TITLE
Preview: PDF Audiowide headings (H1–H4) + dashboard Assessment tile

### DIFF
--- a/app/assessments/page.tsx
+++ b/app/assessments/page.tsx
@@ -1,4 +1,6 @@
 'use client'
+// Preview build trigger: no functional change
+
 
 import React, { useState, useEffect } from 'react'
 import { AppLayout } from '../components/app-layout'


### PR DESCRIPTION
This PR exists to generate a Vercel Preview for recent changes:

- PDF: Standardize section headings to Audiowide (H1–H4) with helper
- Font loading: add fallback to Google Fonts raw TTFs if /public/fonts not present
- Dashboard: add "Assessment" quick action linking to /assessments

Please verify in the Preview build:
- Assessment → Export PDF → All section titles render in Audiowide
- Dashboard shows the Assessment tile and the link works

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author