### PR TITLE
Payments: auto-complete after Stripe redirect (accept payment._id or id)

### DIFF
--- a/app/payments/[id]/page.tsx
+++ b/app/payments/[id]/page.tsx
@@ -347,7 +347,7 @@ export default function PaymentDetailPage() {
       const usp = new URLSearchParams(typeof window !== 'undefined' ? window.location.search : '')
       const status = usp.get('status')
       const sessionId = usp.get('session_id')
-      if (status === 'success' && sessionId && payment?.id) {
+      if (status === 'success' && sessionId && ((payment as any)?._id || (payment as any)?.id)) {
         ;(async () => {
           try {
             await fetch(`/api/payments/${(payment as any)._id || payment.id}/complete`, {


### PR DESCRIPTION
This fixes the post-Stripe redirect completion path on the Payment Details page.

Problem
- After successful Stripe Checkout redirect, the page conditionally posted to `/api/payments/[id]/complete` only when `payment.id` existed.
- Our fetched payment object exposes `_id` (Convex) and sometimes `id` is absent.
- Result: completion never fired, UI stayed Pending even though Stripe returned success.

Change
- Update the success condition to accept either `_id` or `id`:

```
if (status === 'success' && sessionId && ((payment as any)?._id || (payment as any)?.id)) {
```

Impact
- On success redirect, the app now posts to the complete endpoint and marks the payment as `paid`.
- Verified in Test mode with a real Kevin Houston $1 test payment.

Notes
- Separate issue: `/api/payments/create-one-time` returned 500 during testing; not part of this fix. We can address that route next.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author