### PR TITLE
Payments API: harden create-one-time endpoint (validation + server convex client)

### DIFF
--- a/app/api/payments/create-one-time/route.ts
+++ b/app/api/payments/create-one-time/route.ts
@@ -2,44 +2,69 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from 'next/server'
-import { ConvexHttpClient } from 'convex/browser'
+import { z } from 'zod'
 import { api } from '@/convex/_generated/api'
-
-function getConvex() {
-  const url = process.env.NEXT_PUBLIC_CONVEX_URL || process.env.CONVEX_URL
-  if (!url) throw new Error('Convex URL not configured')
-  return new ConvexHttpClient(url)
-}
+import { convexHttp } from '../../../lib/convex-server'
 
 export async function POST(request: NextRequest) {
   try {
-    const { parentId, amount, dueDate, paymentMethod } = await request.json()
-    if (!parentId || !amount) {
-      return NextResponse.json({ error: 'Missing parentId or amount' }, { status: 400 })
+    const raw = await request.json().catch(() => ({}))
+
+    const schema = z.object({
+      parentId: z.string().min(25, 'Invalid parentId'),
+      amount: z.union([z.number(), z.string()]),
+      dueDate: z.union([z.number(), z.string()]).optional(),
+      paymentMethod: z.string().optional(),
+    })
+
+    const parsed = schema.safeParse(raw)
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten().formErrors.join('; ') || 'Invalid payload' }, { status: 400 })
     }
 
-    const convex = getConvex()
+    const { parentId, amount, dueDate, paymentMethod } = parsed.data
+
+    // Normalize amount
+    const amountNum = typeof amount === 'string' ? Number(amount) : amount
+    if (!Number.isFinite(amountNum) || amountNum <= 0) {
+      return NextResponse.json({ error: 'Invalid amount' }, { status: 400 })
+    }
+
+    // Normalize due date (accept number, numeric string, or ISO)
+    let dueDateNum = Date.now()
+    if (typeof dueDate === 'number' && dueDate > 0) {
+      dueDateNum = dueDate
+    } else if (typeof dueDate === 'string' && dueDate.trim() !== '') {
+      const n = Number(dueDate)
+      if (Number.isFinite(n) && n > 0) {
+        dueDateNum = n
+      } else {
+        const ts = Date.parse(dueDate)
+        if (!Number.isNaN(ts)) dueDateNum = ts
+      }
+    }
 
     // Verify parent exists to avoid cross-project ID issues
     try {
-      const parent = await convex.query(api.parents.getParent as any, { id: parentId as any })
+      const parent = await convexHttp.query(api.parents.getParent as any, { id: parentId as any })
       if (!parent) {
-        return NextResponse.json({ error: `Parent not found: ${parentId}` }, { status: 400 })
+        return NextResponse.json({ error: `Parent not found: ${parentId}` }, { status: 404 })
       }
     } catch (e: any) {
-      return NextResponse.json({ error: `Parent lookup failed: ${e?.message || 'unknown'}` }, { status: 500 })
+      return NextResponse.json({ error: `Parent lookup failed: ${e?.message || 'unknown'}` }, { status: 400 })
     }
 
-    const paymentId = await convex.mutation(api.payments.createPayment, {
-      parentId,
-      amount: Number(amount),
-      dueDate: Number(dueDate || Date.now()),
+    const paymentId = await (convexHttp as any).mutation(api.payments.createPayment, {
+      parentId: parentId as any,
+      amount: amountNum,
+      dueDate: dueDateNum,
       status: 'pending',
       paymentMethod: paymentMethod || 'stripe_card',
     })
 
     return NextResponse.json({ paymentId })
   } catch (error: any) {
+    console.error('create-one-time error:', error)
     return NextResponse.json({ error: error?.message || 'Failed to create one-time payment' }, { status: 500 })
   }
 }


### PR DESCRIPTION
This improves reliability of the create-one-time payments endpoint.

Changes
- Use server-side Convex HTTP client (convexHttp) instead of instantiating a new client per-request
- Validate and normalize payload with zod (parentId, amount, dueDate, paymentMethod)
- Normalize dueDate: supports number, numeric string, or ISO string; defaults to now
- Better error handling for invalid parentId and missing parent
- Return 404 when parent not found; 400 for bad payload/ID; keep 500 for unexpected errors

Motivation
- Previously, malformed inputs (e.g., non-numeric dueDate) or invalid parentId could surface as 500s.
- This path is used by the front-end one-time payment flow prior to Stripe checkout; avoiding 500s helps UX.

Tested
- Local static analysis; no behavior change for valid requests
- Stripe flow unaffected (this route only creates the Convex payment record)

Follow-up
- We can add an e2e to hit this route with various dueDate formats and assert responses.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author