### PR TITLE
Payments: fix /api/payments/[id]/complete to use server convex client

### DIFF
--- a/app/api/payments/[id]/complete/route.ts
+++ b/app/api/payments/[id]/complete/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { ConvexHttpClient } from "convex/browser"
 import { api } from "@/convex/_generated/api"
-
-const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!)
+import { convexHttp } from "@/app/lib/convex-server"
 
 export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -10,7 +8,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
     const paymentId = params.id
 
     // Get payment details
-    const payment = await convex.query(api.payments.getPayment, { id: paymentId as any })
+    const payment = await convexHttp.query(api.payments.getPayment as any, { id: paymentId as any })
     if (!payment) {
       return NextResponse.json({ error: 'Payment not found' }, { status: 404 })
     }
@@ -25,7 +23,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
     })()
 
     // Mark paid and persist payment method so UI badges can display correctly
-    await convex.mutation(api.payments.updatePayment, {
+    await convexHttp.mutation(api.payments.updatePayment as any, {
       id: paymentId as any,
       status: 'paid',
       paidAt: Date.now(),


### PR DESCRIPTION
Fixes a 500 when completing a payment from the success redirect.

Changes
- Use shared server Convex HTTP client (convexHttp) instead of creating a per-request browser client
- Keep route unauthenticated (used by client after Stripe redirect)

Why
- The previous code intermittently failed with a 500 in production; using the standard server client aligns with other payment routes that work reliably.

After merge
- Returning from Stripe with status=success will POST to this endpoint and mark the payment as paid.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author