### PR TITLE
Payments complete API: fix import paths (relative) for prod reliability

### DIFF
--- a/app/api/payments/[id]/complete/route.ts
+++ b/app/api/payments/[id]/complete/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { api } from "@/convex/_generated/api"
-import { convexHttp } from "@/lib/convex-server"
+import { api } from "../../../../convex/_generated/api"
+import { convexHttp } from "../../../../lib/convex-server"
 
 export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
   try {


### PR DESCRIPTION
Use relative imports in /api/payments/[id]/complete to avoid alias resolution issues in production:
- api import: @/convex/_generated/api -> ../../../../convex/_generated/api
- convexHttp import: @/lib/convex-server -> ../../../../lib/convex-server

This should resolve the 500s currently observed when POSTing to /api/payments/[id]/complete in production.

Post-merge: I will re-test the auto-complete endpoint to confirm it returns 200 and updates status to paid.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author