### PR TITLE
Payments complete API: set runtime=nodejs + force-dynamic

### DIFF
--- a/app/api/payments/[id]/complete/route.ts
+++ b/app/api/payments/[id]/complete/route.ts
@@ -1,3 +1,7 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+
 import { NextRequest, NextResponse } from 'next/server'
 import { api } from "../../../../convex/_generated/api"
 import { convexHttp } from "../../../../lib/convex-server"
@@ -43,4 +47,4 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
     console.error('Error completing payment:', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
-} 
+}


### PR DESCRIPTION
Follow-up to PR #13: explicitly set export const runtime = "nodejs" and dynamic = "force-dynamic" on /api/payments/[id]/complete to ensure correct runtime and disable caching in production deployments.

After merge, I will re-test the endpoint on production.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author