### PR TITLE
Payments complete API: add error details in 500 response (debug)

### DIFF
--- a/app/api/payments/[id]/complete/route.ts
+++ b/app/api/payments/[id]/complete/route.ts
@@ -43,8 +43,9 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
       paymentId: paymentId
     })
 
-  } catch (error) {
+  } catch (error: any) {
+    const message = error?.message || String(error)
     console.error('Error completing payment:', error)
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    return NextResponse.json({ error: 'Internal server error', details: message }, { status: 500 })
   }
 }


### PR DESCRIPTION
Expose error.message in /api/payments/[id]/complete 500 response to diagnose production 500s. Will revert once resolved.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author