### PR TITLE
CI: Playwright on push + PR; Convex plan fix & cron env wiring

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,6 +1,9 @@
 name: E2E - Playwright
 
 on:
+  push:
+    branches:
+      - "**"
   pull_request:
     branches: [ main, develop, dev, staging ]
   workflow_dispatch:

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,0 +1,56 @@
+name: E2E - Playwright
+
+on:
+  pull_request:
+    branches: [ main, develop, dev, staging ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+
+    env:
+      # Base URL for tests. Prefer secret if set; fallback to production.
+      E2E_BASE_URL: ${{ secrets.E2E_BASE_URL || 'https://ra1dashboard.vercel.app' }}
+      # Useful for Playwright HTML report retention
+      PLAYWRIGHT_JUNIT_OUTPUT_NAME: junit.xml
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests (list reporter)
+        run: npx playwright test --reporter=list --config=playwright.config.ts
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          if-no-files-found: ignore
+
+      - name: Upload test results (videos, screenshots)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results/
+          if-no-files-found: ignore
+

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,4 +1,4 @@
-import { cronJobs } from "@convex-dev/cron";
+import { cronJobs } from "convex/server";
 import { internal } from "./_generated/api";
 import Stripe from "stripe";
 
@@ -13,8 +13,7 @@ crons.interval(
 crons.interval(
   "process due payments",
   { minutes: 1 }, // Run every minute
-  internal.payments.processDuePayments,
-  { stripe: new Stripe(process.env.STRIPE_SECRET_KEY!) }
+  internal.payments.processDuePayments
 );
 
 export default crons;

--- a/convex/payment_plans.ts
+++ b/convex/payment_plans.ts
@@ -3,7 +3,7 @@ import { v } from "convex/values";
 
 export const createPaymentPlan = mutation({
   args: {
-    parentId: v.string(),
+    parentId: v.id("parents"),
     startDate: v.string(),
     paymentMethod: v.string(),
     type: v.string(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "clsx": "2.1.1",
         "cmdk": "1.0.0",
         "convex": "^1.25.4",
+        "convex-helpers": "^0.1.104",
         "cookie": "1.0.2",
         "csv": "6.3.11",
         "csv-parser": "^3.2.0",
@@ -111,6 +112,7 @@
       },
       "devDependencies": {
         "@next/swc-wasm-nodejs": "13.5.1",
+        "@playwright/test": "^1.55.0",
         "@types/node": "24.1.0",
         "@types/react": "18.2.22",
         "@types/react-dom": "18.2.7",
@@ -2723,6 +2725,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@plotly/d3": {
@@ -8204,6 +8222,40 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/convex-helpers": {
+      "version": "0.1.104",
+      "resolved": "https://registry.npmjs.org/convex-helpers/-/convex-helpers-0.1.104.tgz",
+      "integrity": "sha512-7CYvx7T3K6n+McDTK4ZQaQNNGBzq5aWezpjzsKbOxPXx7oNcTP9wrpef3JxeXWFzkByJv5hRCjseh9B7eNJ7Ig==",
+      "license": "Apache-2.0",
+      "bin": {
+        "convex-helpers": "bin.cjs"
+      },
+      "peerDependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "convex": "^1.24.0",
+        "hono": "^4.0.5",
+        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+        "typescript": "^5.5",
+        "zod": "^3.22.4 || ^4.0.15"
+      },
+      "peerDependenciesMeta": {
+        "@standard-schema/spec": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
           "optional": true
         }
       }
@@ -14977,6 +15029,53 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plotly.js": {
       "version": "2.35.3",
       "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.35.3.tgz",
@@ -18477,7 +18576,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@next/swc-wasm-nodejs": "13.5.1",
+    "@playwright/test": "^1.55.0",
     "@types/node": "24.1.0",
     "@types/react": "18.2.22",
     "@types/react-dom": "18.2.7",
@@ -91,6 +92,7 @@
     "clsx": "2.1.1",
     "cmdk": "1.0.0",
     "convex": "^1.25.4",
+    "convex-helpers": "^0.1.104",
     "cookie": "1.0.2",
     "csv": "6.3.11",
     "csv-parser": "^3.2.0",


### PR DESCRIPTION
This PR enables Playwright E2E to run on both push (all branches) and pull_request, and includes:

- CI: Add .github/workflows/e2e-playwright.yml with Playwright setup and artifacts
- CI: Run on push for all branches in addition to PRs
- Convex: Fix legacy payment_plans.createPaymentPlan (parentId v.id("parents")) to stop 500s
- Convex: Use convex/server cronJobs; avoid constructing Stripe at module init
- Convex: Wire Stripe via env in processDuePayments (STRIPE_SECRET_KEY) and make optional

All E2E tests pass locally against production (one-time + 9-month + 4-month + custom). After merge, CI will run on PRs and on future pushes.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author